### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: run clean
+
+run:
+	go run main.go
+
+clean:
+	go clean


### PR DESCRIPTION
This PR adds a Makefile to simplify running the Go program.

The Makefile includes two targets:
- `make run`: Runs the Go program
- `make clean`: Cleans up build artifacts

To use it, simply run:
```bash
make run
```